### PR TITLE
feat: change the way excluded addresses are specified

### DIFF
--- a/api/v1alpha1/client/affiliate.proto
+++ b/api/v1alpha1/client/affiliate.proto
@@ -24,11 +24,12 @@ message KubeSpan {
     string public_key = 1;
     bytes address = 2;
     repeated IPPrefix additional_addresses = 3;
-    // Advertised filter is a list of filter expressions ("(!?)<cidr>") applied
-    // to the additional_addresses and addresses.
-    // If the expression starts with "!", the corresponding address is excluded.
-    // Only addresses passing the filter are advertised to other peers.
-    repeated string advertised_filter = 4;
+    // ExcludeAdvertisedAddresses is used to exclude some of the addresses & additional addresses from being advertised to other affiliates.
+    //
+    // The final set of advertised subnets will be calculated as (addresses + additional_addresses) - exclude_advertised_addresses.
+    //
+    // If the list is empty, no exclusion is performed, and the full set is advertised.
+    repeated IPPrefix exclude_advertised_addresses = 4;
 }
 
 // IPPrefix contains CIDR.

--- a/api/v1alpha1/client/pb/affiliate.pb.go
+++ b/api/v1alpha1/client/pb/affiliate.pb.go
@@ -132,13 +132,14 @@ type KubeSpan struct {
 	PublicKey           string                 `protobuf:"bytes,1,opt,name=public_key,json=publicKey,proto3" json:"public_key,omitempty"`
 	Address             []byte                 `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty"`
 	AdditionalAddresses []*IPPrefix            `protobuf:"bytes,3,rep,name=additional_addresses,json=additionalAddresses,proto3" json:"additional_addresses,omitempty"`
-	// Advertised filter is a list of filter expressions ("(!?)<cidr>") applied
-	// to the additional_addresses and addresses.
-	// If the expression starts with "!", the corresponding address is excluded.
-	// Only addresses passing the filter are advertised to other peers.
-	AdvertisedFilter []string `protobuf:"bytes,4,rep,name=advertised_filter,json=advertisedFilter,proto3" json:"advertised_filter,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// ExcludeAdvertisedAddresses is used to exclude some of the addresses & additional addresses from being advertised to other affiliates.
+	//
+	// The final set of advertised subnets will be calculated as (addresses + additional_addresses) - exclude_advertised_addresses.
+	//
+	// If the list is empty, no exclusion is performed, and the full set is advertised.
+	ExcludeAdvertisedAddresses []*IPPrefix `protobuf:"bytes,4,rep,name=exclude_advertised_addresses,json=excludeAdvertisedAddresses,proto3" json:"exclude_advertised_addresses,omitempty"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *KubeSpan) Reset() {
@@ -192,9 +193,9 @@ func (x *KubeSpan) GetAdditionalAddresses() []*IPPrefix {
 	return nil
 }
 
-func (x *KubeSpan) GetAdvertisedFilter() []string {
+func (x *KubeSpan) GetExcludeAdvertisedAddresses() []*IPPrefix {
 	if x != nil {
-		return x.AdvertisedFilter
+		return x.ExcludeAdvertisedAddresses
 	}
 	return nil
 }
@@ -369,13 +370,13 @@ const file_v1alpha1_client_pb_affiliate_proto_rawDesc = "" +
 	"\bkubespan\x18\a \x01(\v2!.sidero.discovery.client.KubeSpanH\x00R\bkubespan\x88\x01\x01\x12O\n" +
 	"\rcontrol_plane\x18\b \x01(\v2%.sidero.discovery.client.ControlPlaneH\x01R\fcontrolPlane\x88\x01\x01B\v\n" +
 	"\t_kubespanB\x10\n" +
-	"\x0e_control_plane\"\xc6\x01\n" +
+	"\x0e_control_plane\"\xfe\x01\n" +
 	"\bKubeSpan\x12\x1d\n" +
 	"\n" +
 	"public_key\x18\x01 \x01(\tR\tpublicKey\x12\x18\n" +
 	"\aaddress\x18\x02 \x01(\fR\aaddress\x12T\n" +
-	"\x14additional_addresses\x18\x03 \x03(\v2!.sidero.discovery.client.IPPrefixR\x13additionalAddresses\x12+\n" +
-	"\x11advertised_filter\x18\x04 \x03(\tR\x10advertisedFilter\".\n" +
+	"\x14additional_addresses\x18\x03 \x03(\v2!.sidero.discovery.client.IPPrefixR\x13additionalAddresses\x12c\n" +
+	"\x1cexclude_advertised_addresses\x18\x04 \x03(\v2!.sidero.discovery.client.IPPrefixR\x1aexcludeAdvertisedAddresses\".\n" +
 	"\bIPPrefix\x12\x0e\n" +
 	"\x02ip\x18\x01 \x01(\fR\x02ip\x12\x12\n" +
 	"\x04bits\x18\x02 \x01(\rR\x04bits\".\n" +
@@ -409,11 +410,12 @@ var file_v1alpha1_client_pb_affiliate_proto_depIdxs = []int32{
 	1, // 0: sidero.discovery.client.Affiliate.kubespan:type_name -> sidero.discovery.client.KubeSpan
 	4, // 1: sidero.discovery.client.Affiliate.control_plane:type_name -> sidero.discovery.client.ControlPlane
 	2, // 2: sidero.discovery.client.KubeSpan.additional_addresses:type_name -> sidero.discovery.client.IPPrefix
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	2, // 3: sidero.discovery.client.KubeSpan.exclude_advertised_addresses:type_name -> sidero.discovery.client.IPPrefix
+	4, // [4:4] is the sub-list for method output_type
+	4, // [4:4] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_v1alpha1_client_pb_affiliate_proto_init() }

--- a/api/v1alpha1/client/pb/affiliate_vtproto.pb.go
+++ b/api/v1alpha1/client/pb/affiliate_vtproto.pb.go
@@ -70,10 +70,12 @@ func (m *KubeSpan) CloneVT() *KubeSpan {
 		}
 		r.AdditionalAddresses = tmpContainer
 	}
-	if rhs := m.AdvertisedFilter; rhs != nil {
-		tmpContainer := make([]string, len(rhs))
-		copy(tmpContainer, rhs)
-		r.AdvertisedFilter = tmpContainer
+	if rhs := m.ExcludeAdvertisedAddresses; rhs != nil {
+		tmpContainer := make([]*IPPrefix, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.ExcludeAdvertisedAddresses = tmpContainer
 	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -222,13 +224,21 @@ func (this *KubeSpan) EqualVT(that *KubeSpan) bool {
 			}
 		}
 	}
-	if len(this.AdvertisedFilter) != len(that.AdvertisedFilter) {
+	if len(this.ExcludeAdvertisedAddresses) != len(that.ExcludeAdvertisedAddresses) {
 		return false
 	}
-	for i, vx := range this.AdvertisedFilter {
-		vy := that.AdvertisedFilter[i]
-		if vx != vy {
-			return false
+	for i, vx := range this.ExcludeAdvertisedAddresses {
+		vy := that.ExcludeAdvertisedAddresses[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &IPPrefix{}
+			}
+			if q == nil {
+				q = &IPPrefix{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
 		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -431,11 +441,14 @@ func (m *KubeSpan) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
-	if len(m.AdvertisedFilter) > 0 {
-		for iNdEx := len(m.AdvertisedFilter) - 1; iNdEx >= 0; iNdEx-- {
-			i -= len(m.AdvertisedFilter[iNdEx])
-			copy(dAtA[i:], m.AdvertisedFilter[iNdEx])
-			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.AdvertisedFilter[iNdEx])))
+	if len(m.ExcludeAdvertisedAddresses) > 0 {
+		for iNdEx := len(m.ExcludeAdvertisedAddresses) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.ExcludeAdvertisedAddresses[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
 			i--
 			dAtA[i] = 0x22
 		}
@@ -661,9 +674,9 @@ func (m *KubeSpan) SizeVT() (n int) {
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
-	if len(m.AdvertisedFilter) > 0 {
-		for _, s := range m.AdvertisedFilter {
-			l = len(s)
+	if len(m.ExcludeAdvertisedAddresses) > 0 {
+		for _, e := range m.ExcludeAdvertisedAddresses {
+			l = e.SizeVT()
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
@@ -1164,9 +1177,9 @@ func (m *KubeSpan) UnmarshalVT(dAtA []byte) error {
 			iNdEx = postIndex
 		case 4:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field AdvertisedFilter", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field ExcludeAdvertisedAddresses", wireType)
 			}
-			var stringLen uint64
+			var msglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return protohelpers.ErrIntOverflow
@@ -1176,23 +1189,25 @@ func (m *KubeSpan) UnmarshalVT(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
+			if msglen < 0 {
 				return protohelpers.ErrInvalidLength
 			}
-			postIndex := iNdEx + intStringLen
+			postIndex := iNdEx + msglen
 			if postIndex < 0 {
 				return protohelpers.ErrInvalidLength
 			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			m.AdvertisedFilter = append(m.AdvertisedFilter, string(dAtA[iNdEx:postIndex]))
+			m.ExcludeAdvertisedAddresses = append(m.ExcludeAdvertisedAddresses, &IPPrefix{})
+			if err := m.ExcludeAdvertisedAddresses[len(m.ExcludeAdvertisedAddresses)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex


### PR DESCRIPTION
The previous PR change has never been released, so it's still fine to change the structure.

Instead of relying on filter expression which is somewhat confusing, and it doesn't allow proper exclusion of subnets (it matches on the address part of the subnet only).

With this change, we can do the following:

1. The machine advertises address "10.0.0.0/8".
2. By default the whole "/8" block will be advertised.
3. We can make exclusion subnet "10.0.128.0/9", which will reduce advertised addresses to "10.0.0.0/9".